### PR TITLE
fix: correct path on Windows to create and delete typegen file

### DIFF
--- a/client/src/typegenService.ts
+++ b/client/src/typegenService.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import * as path from "path";
+import * as os from "os";
 import * as prettier from "prettier";
 import { promisify } from "util";
 import * as vscode from "vscode";
@@ -49,7 +49,11 @@ const throttledTypegenCreationMachine = createMachine<
         await Promise.all([
           Object.entries(context.eventMap).map(async ([, event]) => {
             const uri = event.uri;
-            const pathFromUri = vscode.Uri.parse(uri, true).path.slice(1);
+            let pathFromUri = vscode.Uri.parse(uri, true).path;
+            if (os.platform() === "win32") {
+              pathFromUri = pathFromUri.slice(1);
+            }
+
             const pathToSave = pathFromUri.replace(
               /\.([j,t])sx?$/,
               ".typegen.ts",

--- a/client/src/typegenService.ts
+++ b/client/src/typegenService.ts
@@ -49,14 +49,13 @@ const throttledTypegenCreationMachine = createMachine<
         await Promise.all([
           Object.entries(context.eventMap).map(async ([, event]) => {
             const uri = event.uri;
-
-            const newUri = vscode.Uri.file(
-              uri.replace(/\.([j,t])sx?$/, ".typegen.ts"),
+            const pathFromUri = vscode.Uri.parse(uri, true).path.slice(1);
+            const pathToSave = pathFromUri.replace(
+              /\.([j,t])sx?$/,
+              ".typegen.ts",
             );
 
-            const pathToSave = path.resolve(newUri.path).slice(6);
-
-            const prettierConfig = await prettier.resolveConfig(uri.slice(6));
+            const prettierConfig = await prettier.resolveConfig(pathFromUri);
 
             if (
               event.machines.filter((machine) => machine.hasTypesNode).length >
@@ -71,7 +70,7 @@ const throttledTypegenCreationMachine = createMachine<
                 }),
               );
             } else {
-              await promisify(fs.unlink)(path.resolve(newUri.path).slice(6));
+              await promisify(fs.unlink)(pathToSave);
             }
           }),
         ]);


### PR DESCRIPTION
Hello Matt,

Thanks for your work on XState, it's amazing and inspiring!

On Windows, the typegen file is not generated. I followed the lead you wrote in the issue #40.
I fixed the issue on Windows. Unfortunately, I don't have a Mac, so I was unable to test on macOs. But maybe, it can help you.

I used `vscode.Uri.parse` to extract the path from the URI. But the result is prefixed with a slash that caused `fs.writeFile` to prefix the path with "C:". So I removed this slash with `slice(1)` and it works! (at least on Windows).

Thanks! 